### PR TITLE
add max_collision_pairs constraint for scenes with stairs

### DIFF
--- a/locomotion/wheel_legged_env.py
+++ b/locomotion/wheel_legged_env.py
@@ -60,6 +60,7 @@ class WheelLeggedEnv:
                 enable_collision=True,
                 enable_joint_limit=True,
                 batch_dofs_info=True,
+                max_collision_pairs=64,
                 # batch_links_info=True,
             ),
             show_viewer=show_viewer,


### PR DESCRIPTION
When you add many boxes as stairs, the maximum number of potential collision pairs increases significantly. However, because the added geometry is fixed, the actual number of pairs can’t grow nearly as much. We can manually cap the potential pairs to save memory.